### PR TITLE
Complete iOS hasText validation improvements

### DIFF
--- a/ios/Classes/MobileOcrPlugin.swift
+++ b/ios/Classes/MobileOcrPlugin.swift
@@ -57,10 +57,10 @@ public class MobileOcrPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        // Use higher threshold for hasText to avoid false positives
-        // hasText should be more conservative than detectText
+        // Use same threshold as detectText for consistency
+        // Text validation will filter out false positives
         quickDetectText(imagePath: imagePath,
-                        minConfidence: 0.7,
+                        minConfidence: 0.5,
                         result: result)
     }
 


### PR DESCRIPTION
## Summary
This PR includes the validation improvements that were missing from #3 (PR was merged before all commits were included).

## Changes
- Lower hasText threshold from 0.7 to 0.5 to match detectText
- Require 3+ consecutive alphanumeric characters (not just one)
- Use .accurate recognition mode instead of .fast for consistent confidence scores

## Fixes
- False positives: Rejects gibberish like `*•/• ; 41'4.•/4`
- False negatives: hasText now matches detectText results
- Supports passwords and real text while filtering noise