### PR TITLE
Bump AGP to 8.9.1 for AndroidX compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.3")
+        classpath("com.android.tools.build:gradle:8.9.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 


### PR DESCRIPTION
## Summary
Required for compatibility with image_picker_android 0.8.13 which
pulls in androidx.activity:1.12.2 and androidx.core:1.17.0.

## Testing
All unit tests passed. The example app was also manually tested on a Xiaomi device running Android 15, and everything works fine.

Thanks for open sourcing this great package!

## Original error
Without this fix, new users of the package will get the following error trying to run the demo app on Android:

```bash
❯ flutter run 
Flutter assets will be downloaded from https://storage.flutter-io.cn. Make sure you trust this source!
Launching lib/main.dart on 25080RABDC in debug mode...
Flutter assets will be downloaded from https://storage.flutter-io.cn. Make sure you trust this source!

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 4 issues were found when checking AAR metadata:

       1.  Dependency 'androidx.activity:activity:1.12.2' requires Android Gradle plugin 8.9.1 or higher.

           This build currently uses Android Gradle plugin 8.7.3.

       2.  Dependency 'androidx.core:core-ktx:1.17.0' requires Android Gradle plugin 8.9.1 or higher.

           This build currently uses Android Gradle plugin 8.7.3.

       3.  Dependency 'androidx.core:core:1.17.0' requires Android Gradle plugin 8.9.1 or higher.

           This build currently uses Android Gradle plugin 8.7.3.

       4.  Dependency 'androidx.navigationevent:navigationevent-android:1.0.1' requires Android Gradle plugin 8.9.1 or higher.

           This build currently uses Android Gradle plugin 8.7.3.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 5s
Running Gradle task 'assembleDebug'...                              5.6s
Error: Gradle task assembleDebug failed with exit code 1
```