### PR TITLE
Feat/overlay_only_mode

### DIFF
--- a/android/src/main/kotlin/io/ente/mobile_ocr/MobileOcrPlugin.kt
+++ b/android/src/main/kotlin/io/ente/mobile_ocr/MobileOcrPlugin.kt
@@ -166,7 +166,7 @@ class MobileOcrPlugin: FlutterPlugin, MethodCallHandler {
     }
   }
 
-  private suspend fun processImage(imagePath: String, includeAllConfidenceScores: Boolean = false): List<Map<String, Any>> {
+  private suspend fun processImage(imagePath: String, includeAllConfidenceScores: Boolean = false): Map<String, Any> {
     if (shuttingDown) {
       throw IllegalStateException("Plugin is shutting down")
     }
@@ -183,6 +183,9 @@ class MobileOcrPlugin: FlutterPlugin, MethodCallHandler {
           ?: throw IllegalArgumentException("Failed to decode image at path: $imagePath")
       val correctedBitmap = applyExifOrientation(bitmap, imagePath)
 
+      val imageWidth = correctedBitmap.width
+      val imageHeight = correctedBitmap.height
+
       // Process with OCR
       val ocrResults = processor.processImage(correctedBitmap, includeAllConfidenceScores)
       if (correctedBitmap !== bitmap && !bitmap.isRecycled) {
@@ -193,10 +196,14 @@ class MobileOcrPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       if (ocrResults.texts.isEmpty()) {
-        return emptyList()
+        return hashMapOf(
+          "blocks" to emptyList<Map<String, Any>>(),
+          "imageWidth" to imageWidth,
+          "imageHeight" to imageHeight
+        )
       }
 
-      return ocrResults.boxes.mapIndexed { index, box ->
+      val blocks = ocrResults.boxes.mapIndexed { index, box ->
         val pointMaps: List<Map<String, Double>> = box.points.map { point ->
           mapOf(
             "x" to point.x.toDouble(),
@@ -223,6 +230,12 @@ class MobileOcrPlugin: FlutterPlugin, MethodCallHandler {
           "characters" to characterMaps
         )
       }
+
+      return hashMapOf(
+        "blocks" to blocks,
+        "imageWidth" to imageWidth,
+        "imageHeight" to imageHeight
+      )
     } finally {
       activeTasks.decrementAndGet()
     }

--- a/ios/Classes/MobileOcrPlugin.swift
+++ b/ios/Classes/MobileOcrPlugin.swift
@@ -285,7 +285,11 @@ public class MobileOcrPlugin: NSObject, FlutterPlugin {
 
             // Return results on main thread
             DispatchQueue.main.async {
-                result(detectedTexts)
+                result([
+                    "blocks": detectedTexts,
+                    "imageWidth": cgImage.width,
+                    "imageHeight": cgImage.height
+                ] as [String: Any])
             }
         }
         DispatchQueue.global(qos: .userInitiated).async(execute: workItem)

--- a/lib/mobile_ocr_plugin.dart
+++ b/lib/mobile_ocr_plugin.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:mobile_ocr/models/text_block.dart';
 
@@ -24,7 +25,7 @@ class MobileOcr {
   /// [imagePath] must point to a readable PNG or JPEG file.
   /// By default, only returns results with confidence >= 0.8. Set
   /// [includeAllConfidenceScores] to true to include detections down to 0.5.
-  Future<List<TextBlock>> detectText({
+  Future<TextDetectionResult> detectText({
     required String imagePath,
     bool includeAllConfidenceScores = false,
   }) async {
@@ -33,11 +34,11 @@ class MobileOcr {
       throw ArgumentError('Image file does not exist at path: $imagePath');
     }
 
-    final results = await MobileOcrPlatform.instance.detectText(
+    final result = await MobileOcrPlatform.instance.detectText(
       imagePath: file.path,
       includeAllConfidenceScores: includeAllConfidenceScores,
     );
-    return results.map(TextBlock.fromMap).toList(growable: false);
+    return TextDetectionResult.fromMap(result);
   }
 
   /// Quickly determine whether the image contains high-confidence text.
@@ -51,6 +52,26 @@ class MobileOcr {
     }
 
     return MobileOcrPlatform.instance.hasText(imagePath: file.path);
+  }
+}
+
+/// Result of a text detection operation, including detected blocks and
+/// the source image dimensions.
+class TextDetectionResult {
+  final List<TextBlock> blocks;
+  final Size imageSize;
+
+  TextDetectionResult({required this.blocks, required this.imageSize});
+
+  factory TextDetectionResult.fromMap(Map<dynamic, dynamic> map) {
+    final blocksList = (map['blocks'] as List?)?.cast<Map<dynamic, dynamic>>() ?? const [];
+    final blocks = blocksList.map(TextBlock.fromMap).toList(growable: false);
+    final imageWidth = (map['imageWidth'] as num?)?.toDouble() ?? 0.0;
+    final imageHeight = (map['imageHeight'] as num?)?.toDouble() ?? 0.0;
+    return TextDetectionResult(
+      blocks: blocks,
+      imageSize: Size(imageWidth, imageHeight),
+    );
   }
 }
 

--- a/lib/mobile_ocr_plugin_method_channel.dart
+++ b/lib/mobile_ocr_plugin_method_channel.dart
@@ -18,19 +18,19 @@ class MethodChannelMobileOcr extends MobileOcrPlatform {
   }
 
   @override
-  Future<List<Map<dynamic, dynamic>>> detectText({
+  Future<Map<dynamic, dynamic>> detectText({
     required String imagePath,
     bool includeAllConfidenceScores = false,
   }) async {
     final result =
-        await methodChannel.invokeListMethod<Map<dynamic, dynamic>>(
+        await methodChannel.invokeMapMethod<dynamic, dynamic>(
       'detectText',
       {
         'imagePath': imagePath,
         'includeAllConfidenceScores': includeAllConfidenceScores,
       },
     );
-    return result ?? const [];
+    return result ?? const {};
   }
 
   @override

--- a/lib/mobile_ocr_plugin_platform_interface.dart
+++ b/lib/mobile_ocr_plugin_platform_interface.dart
@@ -27,7 +27,7 @@ abstract class MobileOcrPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Future<List<Map<dynamic, dynamic>>> detectText({
+  Future<Map<dynamic, dynamic>> detectText({
     required String imagePath,
     bool includeAllConfidenceScores = false,
   }) {

--- a/lib/widgets/text_detector_widget.dart
+++ b/lib/widgets/text_detector_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -212,9 +211,7 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
         _resolvedImagePath = resolvedPath;
       });
 
-      if (widget.overlayOnly) {
-        await _readImageDimensions(file);
-      } else {
+      if (!widget.overlayOnly) {
         _precacheCurrentImage();
       }
 
@@ -325,11 +322,12 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
         throw Exception(_errorMessage);
       }
 
-      final blocks = await _ocr.detectText(imagePath: imagePath);
+      final result = await _ocr.detectText(imagePath: imagePath);
 
       if (mounted && widget.imagePath == requestedPath) {
         setState(() {
-          _detectedTextBlocks = blocks;
+          _detectedTextBlocks = result.blocks;
+          _imageSize = result.imageSize;
           _errorMessage = null;
         });
         _notifyController();
@@ -688,19 +686,6 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
 
   void _notifyController() {
     widget.controller?._notifyStateChanged();
-  }
-
-  Future<void> _readImageDimensions(File file) async {
-    final bytes = await file.readAsBytes();
-    final codec = await ui.instantiateImageCodec(bytes);
-    final frame = await codec.getNextFrame();
-    if (!mounted) return;
-    setState(() {
-      _imageSize = Size(
-        frame.image.width.toDouble(),
-        frame.image.height.toDouble(),
-      );
-    });
   }
 
   void _precacheCurrentImage() {

--- a/lib/widgets/text_detector_widget.dart
+++ b/lib/widgets/text_detector_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -111,6 +112,10 @@ class TextDetectorWidget extends StatefulWidget {
   /// Controller for imperative text selection actions.
   final TextDetectorController? controller;
 
+  /// When true, only the text overlay is rendered (no image). Use this when
+  /// the image is already displayed by another widget underneath.
+  final bool overlayOnly;
+
   const TextDetectorWidget({
     super.key,
     required this.imagePath,
@@ -123,6 +128,7 @@ class TextDetectorWidget extends StatefulWidget {
     this.debugMode = false,
     this.strings = const TextDetectorStrings(),
     this.controller,
+    this.overlayOnly = false,
   });
 
   @override
@@ -143,6 +149,7 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
   Timer? _editorHintTimer;
   bool _showEditorHint = false;
   bool _isNetworkError = false;
+  Size? _imageSize;
   bool get _hasSelectableText =>
       _detectedTextBlocks != null && _detectedTextBlocks!.isNotEmpty;
 
@@ -205,7 +212,11 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
         _resolvedImagePath = resolvedPath;
       });
 
-      _precacheCurrentImage();
+      if (widget.overlayOnly) {
+        await _readImageDimensions(file);
+      } else {
+        _precacheCurrentImage();
+      }
 
       if (widget.autoDetect) {
         unawaited(_detectText());
@@ -465,6 +476,9 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
     if (imageFile == null || textBlocks == null) {
       return const SizedBox.shrink();
     }
+    if (widget.overlayOnly && _imageSize == null) {
+      return const SizedBox.shrink();
+    }
 
     final TextSelectionThemeData baseSelectionTheme = TextSelectionTheme.of(
       context,
@@ -482,7 +496,8 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
       child: TextSelectionTheme(
         data: overlaySelectionTheme,
         child: TextOverlayWidget(
-          imageFile: imageFile,
+          imageFile: widget.overlayOnly ? null : imageFile,
+          imageSize: widget.overlayOnly ? _imageSize : null,
           textBlocks: textBlocks,
           onTextBlocksSelected: widget.onTextBlocksSelected,
           onTextCopied: widget.onTextCopied,
@@ -661,6 +676,19 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
 
   void _notifyController() {
     widget.controller?._notifyStateChanged();
+  }
+
+  Future<void> _readImageDimensions(File file) async {
+    final bytes = await file.readAsBytes();
+    final codec = await ui.instantiateImageCodec(bytes);
+    final frame = await codec.getNextFrame();
+    if (!mounted) return;
+    setState(() {
+      _imageSize = Size(
+        frame.image.width.toDouble(),
+        frame.image.height.toDouble(),
+      );
+    });
   }
 
   void _precacheCurrentImage() {

--- a/lib/widgets/text_detector_widget.dart
+++ b/lib/widgets/text_detector_widget.dart
@@ -491,22 +491,34 @@ class _TextDetectorWidgetState extends State<TextDetectorWidget> {
           selectionHandleColor: _entePrimaryColor,
         );
 
+    final overlayWidget = TextOverlayWidget(
+      imageFile: widget.overlayOnly ? null : imageFile,
+      imageSize: widget.overlayOnly ? _imageSize : null,
+      textBlocks: textBlocks,
+      onTextBlocksSelected: widget.onTextBlocksSelected,
+      onTextCopied: widget.onTextCopied,
+      onSelectionStart: _dismissEditorHint,
+      showUnselectedBoundaries: widget.showUnselectedBoundaries,
+      enableSelectionPreview: widget.enableSelectionPreview,
+      debugMode: widget.debugMode,
+      controller: _textOverlayController,
+    );
+
+    // In overlay-only mode, don't wrap in a Container with a color —
+    // even Colors.transparent creates a hit target that blocks the
+    // underlying PageView from receiving swipes.
+    if (widget.overlayOnly) {
+      return TextSelectionTheme(
+        data: overlaySelectionTheme,
+        child: overlayWidget,
+      );
+    }
+
     return Container(
       color: widget.backgroundColor,
       child: TextSelectionTheme(
         data: overlaySelectionTheme,
-        child: TextOverlayWidget(
-          imageFile: widget.overlayOnly ? null : imageFile,
-          imageSize: widget.overlayOnly ? _imageSize : null,
-          textBlocks: textBlocks,
-          onTextBlocksSelected: widget.onTextBlocksSelected,
-          onTextCopied: widget.onTextCopied,
-          onSelectionStart: _dismissEditorHint,
-          showUnselectedBoundaries: widget.showUnselectedBoundaries,
-          enableSelectionPreview: widget.enableSelectionPreview,
-          debugMode: widget.debugMode,
-          controller: _textOverlayController,
-        ),
+        child: overlayWidget,
       ),
     );
   }

--- a/lib/widgets/text_overlay_widget.dart
+++ b/lib/widgets/text_overlay_widget.dart
@@ -48,8 +48,16 @@ class TextOverlayController {
 
 /// A widget that overlays detected text on top of the source image while
 /// providing an editor-like selection experience.
+///
+/// Can operate in two modes:
+/// - **Image mode** (default): Pass [imageFile] and the widget renders the
+///   image with text overlays on top.
+/// - **Overlay-only mode**: Pass [imageSize] instead of [imageFile] and the
+///   widget renders only the transparent text overlay. Use this when the image
+///   is already rendered by another widget (e.g. PhotoView) and you just need
+///   the text selection layer on top.
 class TextOverlayWidget extends StatefulWidget {
-  final File imageFile;
+  final File? imageFile;
   final List<TextBlock> textBlocks;
   final Function(List<TextBlock>)? onTextBlocksSelected;
   final Function(String)? onTextCopied;
@@ -59,9 +67,14 @@ class TextOverlayWidget extends StatefulWidget {
   final bool debugMode;
   final TextOverlayController? controller;
 
+  /// The original image dimensions in pixels. Required when using
+  /// overlay-only mode (no [imageFile]). When [imageFile] is provided
+  /// this is ignored — dimensions are read from the file.
+  final Size? imageSize;
+
   const TextOverlayWidget({
     super.key,
-    required this.imageFile,
+    this.imageFile,
     required this.textBlocks,
     this.onTextBlocksSelected,
     this.onTextCopied,
@@ -70,7 +83,11 @@ class TextOverlayWidget extends StatefulWidget {
     this.enableSelectionPreview = false,
     this.debugMode = false,
     this.controller,
-  });
+    this.imageSize,
+  }) : assert(
+         imageFile != null || imageSize != null,
+         'Either imageFile or imageSize must be provided',
+       );
 
   @override
   State<TextOverlayWidget> createState() => _TextOverlayWidgetState();
@@ -154,7 +171,10 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
       widget.controller?._attach(this);
     }
 
-    if (oldWidget.imageFile.path != widget.imageFile.path) {
+    final bool imageChanged = _isOverlayOnly
+        ? widget.imageSize != oldWidget.imageSize
+        : widget.imageFile?.path != oldWidget.imageFile?.path;
+    if (imageChanged) {
       _resetForNewImage();
       return;
     }
@@ -187,8 +207,21 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
     }
   }
 
+  bool get _isOverlayOnly => widget.imageFile == null;
+
   Future<void> _loadImageDimensions() async {
-    final bytes = await widget.imageFile.readAsBytes();
+    if (widget.imageSize != null) {
+      if (!mounted) return;
+      setState(() {
+        _imageSize = widget.imageSize;
+      });
+      return;
+    }
+
+    final imageFile = widget.imageFile;
+    if (imageFile == null) return;
+
+    final bytes = await imageFile.readAsBytes();
     final codec = await ui.instantiateImageCodec(bytes);
     final frame = await codec.getNextFrame();
     final image = frame.image;
@@ -274,33 +307,37 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
             child: InteractiveViewer(
               key: _interactiveViewerKey,
               transformationController: _transformController,
-              minScale: 0.5,
-              maxScale: 4.0,
-              panEnabled: _isPanEnabled,
+              minScale: _isOverlayOnly ? 1.0 : 0.5,
+              maxScale: _isOverlayOnly ? 1.0 : 4.0,
+              panEnabled: _isOverlayOnly ? false : _isPanEnabled,
+              scaleEnabled: !_isOverlayOnly,
               child: Stack(
                 children: [
-                  Center(
-                    child: Image.file(
-                      widget.imageFile,
-                      fit: BoxFit.contain,
-                      gaplessPlayback: true,
-                      frameBuilder:
-                          (context, child, frame, wasSynchronouslyLoaded) {
-                            if (frame != null) {
-                              _scheduleMetricsRebuild(constraints);
-                            }
-                            if (wasSynchronouslyLoaded) {
-                              return child;
-                            }
-                            return AnimatedOpacity(
-                              opacity: frame == null ? 0 : 1,
-                              duration: const Duration(milliseconds: 200),
-                              curve: Curves.easeOut,
-                              child: child,
-                            );
-                          },
-                    ),
-                  ),
+                  if (!_isOverlayOnly)
+                    Center(
+                      child: Image.file(
+                        widget.imageFile!,
+                        fit: BoxFit.contain,
+                        gaplessPlayback: true,
+                        frameBuilder:
+                            (context, child, frame, wasSynchronouslyLoaded) {
+                              if (frame != null) {
+                                _scheduleMetricsRebuild(constraints);
+                              }
+                              if (wasSynchronouslyLoaded) {
+                                return child;
+                              }
+                              return AnimatedOpacity(
+                                opacity: frame == null ? 0 : 1,
+                                duration: const Duration(milliseconds: 200),
+                                curve: Curves.easeOut,
+                                child: child,
+                              );
+                            },
+                      ),
+                    )
+                  else
+                    const SizedBox.expand(),
                   ..._buildEditableBlockOverlays(),
                   ..._buildSelectionHandles(),
                   if (copyButton != null) copyButton,

--- a/lib/widgets/text_overlay_widget.dart
+++ b/lib/widgets/text_overlay_widget.dart
@@ -294,7 +294,9 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
           onPointerUp: _handlePointerUp,
           onPointerCancel: _handlePointerCancel,
           child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
+            behavior: _isOverlayOnly
+                ? HitTestBehavior.translucent
+                : HitTestBehavior.opaque,
             onTapDown: _handleTapDown,
             onDoubleTapDown: _handleDoubleTapDown,
             onDoubleTap: _handleDoubleTap,

--- a/lib/widgets/text_overlay_widget.dart
+++ b/lib/widgets/text_overlay_widget.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:mobile_ocr/models/text_block.dart';
 
@@ -283,56 +284,113 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
   }
 
   Widget _buildInteractiveImage() {
+    if (_isOverlayOnly) {
+      return _buildOverlayOnlyImage();
+    }
     return LayoutBuilder(
       builder: (context, constraints) {
         _scheduleMetricsRebuild(constraints);
         final Widget? copyButton = _buildCopyHandleButton(constraints);
 
         final Widget interactiveChild = InteractiveViewer(
-              key: _interactiveViewerKey,
-              transformationController: _transformController,
-              minScale: _isOverlayOnly ? 1.0 : 0.5,
-              maxScale: _isOverlayOnly ? 1.0 : 4.0,
-              panEnabled: _isOverlayOnly ? false : _isPanEnabled,
-              scaleEnabled: !_isOverlayOnly,
-              child: Stack(
-                children: [
-                  if (!_isOverlayOnly)
-                    Center(
-                      child: Image.file(
-                        widget.imageFile!,
-                        fit: BoxFit.contain,
-                        gaplessPlayback: true,
-                        frameBuilder:
-                            (context, child, frame, wasSynchronouslyLoaded) {
-                              if (frame != null) {
-                                _scheduleMetricsRebuild(constraints);
-                              }
-                              if (wasSynchronouslyLoaded) {
-                                return child;
-                              }
-                              return AnimatedOpacity(
-                                opacity: frame == null ? 0 : 1,
-                                duration: const Duration(milliseconds: 200),
-                                curve: Curves.easeOut,
-                                child: child,
-                              );
-                            },
-                      ),
-                    )
-                  else
-                    const SizedBox.expand(),
-                  ..._buildEditableBlockOverlays(),
-                  ..._buildSelectionHandles(),
-                  if (copyButton != null) copyButton,
-                ],
+          key: _interactiveViewerKey,
+          transformationController: _transformController,
+          minScale: 0.5,
+          maxScale: 4.0,
+          panEnabled: _isPanEnabled,
+          scaleEnabled: true,
+          child: Stack(
+            children: [
+              Center(
+                child: Image.file(
+                  widget.imageFile!,
+                  fit: BoxFit.contain,
+                  gaplessPlayback: true,
+                  frameBuilder:
+                      (context, child, frame, wasSynchronouslyLoaded) {
+                        if (frame != null) {
+                          _scheduleMetricsRebuild(constraints);
+                        }
+                        if (wasSynchronouslyLoaded) {
+                          return child;
+                        }
+                        return AnimatedOpacity(
+                          opacity: frame == null ? 0 : 1,
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          child: child,
+                        );
+                      },
+                ),
               ),
-            );
+              ..._buildEditableBlockOverlays(),
+              ..._buildSelectionHandles(),
+              if (copyButton != null) copyButton,
+            ],
+          ),
+        );
 
-        final Widget gestureChild;
-        if (_isOverlayOnly) {
-          gestureChild = RawGestureDetector(
-            behavior: HitTestBehavior.translucent,
+        return Listener(
+          onPointerDown: _handlePointerDown,
+          onPointerMove: _handlePointerMove,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: _handlePointerCancel,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: _handleTapDown,
+            onDoubleTapDown: _handleDoubleTapDown,
+            onDoubleTap: _handleDoubleTap,
+            onLongPressStart: (details) {
+              if (_activePointerCount > 1) return;
+              _onLongPressStart(details);
+            },
+            child: interactiveChild,
+          ),
+        );
+      },
+    );
+  }
+
+  /// Overlay-only mode: renders text boundaries and handles without any
+  /// image, and crucially without intercepting gestures. The entire visual
+  /// layer is wrapped in [IgnorePointer] so swipes/taps pass through to
+  /// the underlying PageView / PhotoView. A [_TextRegionHitTestBox] sits
+  /// on top and only reports hits when the touch lands on a text region,
+  /// allowing long-press-to-select without blocking navigation.
+  Widget _buildOverlayOnlyImage() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _scheduleMetricsRebuild(constraints);
+        final Widget? copyButton = _buildCopyHandleButton(constraints);
+
+        // All visual content shares the same KeyedSubtree so coordinates
+        // are consistent. Text boundaries are in IgnorePointer; selection
+        // handles and copy button are outside it so they can be touched.
+        final Widget visualLayer = KeyedSubtree(
+          key: _interactiveViewerKey,
+          child: Stack(
+            children: [
+              IgnorePointer(
+                child: Stack(
+                  children: [
+                    const SizedBox.expand(),
+                    ..._buildEditableBlockOverlays(),
+                  ],
+                ),
+              ),
+              ..._buildSelectionHandles(),
+              if (copyButton != null) copyButton,
+            ],
+          ),
+        );
+
+        // Gesture layer: only intercepts touches on text regions
+        // or selection handles. Uses a custom RenderBox that returns
+        // false from hitTest unless the position passes the check.
+        final Widget gestureLayer = _TextRegionHitTestBox(
+          hitTest: _isPositionOnText,
+          child: RawGestureDetector(
+            behavior: HitTestBehavior.opaque,
             gestures: <Type, GestureRecognizerFactory>{
               _TextRegionLongPressRecognizer:
                   GestureRecognizerFactoryWithHandlers<
@@ -359,28 +417,22 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
                       },
                     ),
             },
-            child: interactiveChild,
-          );
-        } else {
-          gestureChild = GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTapDown: _handleTapDown,
-            onDoubleTapDown: _handleDoubleTapDown,
-            onDoubleTap: _handleDoubleTap,
-            onLongPressStart: (details) {
-              if (_activePointerCount > 1) return;
-              _onLongPressStart(details);
-            },
-            child: interactiveChild,
-          );
-        }
+            child: Listener(
+              behavior: HitTestBehavior.translucent,
+              onPointerDown: _handlePointerDown,
+              onPointerMove: _handlePointerMove,
+              onPointerUp: _handlePointerUp,
+              onPointerCancel: _handlePointerCancel,
+              child: const SizedBox.expand(),
+            ),
+          ),
+        );
 
-        return Listener(
-          onPointerDown: _handlePointerDown,
-          onPointerMove: _handlePointerMove,
-          onPointerUp: _handlePointerUp,
-          onPointerCancel: _handlePointerCancel,
-          child: gestureChild,
+        return Stack(
+          children: [
+            visualLayer,
+            gestureLayer,
+          ],
         );
       },
     );
@@ -389,6 +441,10 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
   bool _isPositionOnText(Offset globalPosition) {
     final scenePoint = _sceneFromGlobal(globalPosition);
     if (scenePoint == null) return false;
+    // Also accept hits on selection handles so they can be dragged.
+    if (_activeSelections.isNotEmpty && _isScenePointOnHandle(scenePoint)) {
+      return true;
+    }
     return _hitTestBlock(scenePoint) != null;
   }
 
@@ -2583,6 +2639,47 @@ class _EditableBlockPainter extends CustomPainter {
 /// A [LongPressGestureRecognizer] that only accepts when the press
 /// position is on a text region. If not on text, it rejects so that
 /// competing recognizers (e.g. motion photo playback) can win.
+/// A [SingleChildRenderObjectWidget] whose render object only reports a hit
+/// when the touch position passes the provided [hitTest] callback. This lets
+/// the overlay be invisible to Flutter's hit-test tree for most of the screen
+/// area, so the underlying PageView / PhotoView receives swipes and taps.
+class _TextRegionHitTestBox extends SingleChildRenderObjectWidget {
+  final bool Function(Offset globalPosition) hitTest;
+
+  const _TextRegionHitTestBox({
+    required this.hitTest,
+    required super.child,
+  });
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderTextRegionHitTestBox(hitTest);
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderTextRegionHitTestBox renderObject,
+  ) {
+    renderObject.hitTestCallback = hitTest;
+  }
+}
+
+class _RenderTextRegionHitTestBox extends RenderProxyBox {
+  bool Function(Offset globalPosition) hitTestCallback;
+
+  _RenderTextRegionHitTestBox(this.hitTestCallback);
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    final global = localToGlobal(position);
+    if (!hitTestCallback(global)) {
+      return false;
+    }
+    return super.hitTest(result, position: position);
+  }
+}
+
 class _TextRegionLongPressRecognizer extends LongPressGestureRecognizer {
   bool Function(Offset globalPosition) hitTestBlock;
 

--- a/lib/widgets/text_overlay_widget.dart
+++ b/lib/widgets/text_overlay_widget.dart
@@ -288,27 +288,7 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
         _scheduleMetricsRebuild(constraints);
         final Widget? copyButton = _buildCopyHandleButton(constraints);
 
-        return Listener(
-          onPointerDown: _handlePointerDown,
-          onPointerMove: _handlePointerMove,
-          onPointerUp: _handlePointerUp,
-          onPointerCancel: _handlePointerCancel,
-          child: GestureDetector(
-            behavior: _isOverlayOnly
-                ? HitTestBehavior.translucent
-                : HitTestBehavior.opaque,
-            onTapDown: _isOverlayOnly
-                ? (_activeSelections.isNotEmpty ? _handleOverlayTap : null)
-                : _handleTapDown,
-            onDoubleTapDown: _isOverlayOnly ? null : _handleDoubleTapDown,
-            onDoubleTap: _isOverlayOnly ? null : _handleDoubleTap,
-            onLongPressStart: (details) {
-              if (_activePointerCount > 1) {
-                return;
-              }
-              _onLongPressStart(details);
-            },
-            child: InteractiveViewer(
+        final Widget interactiveChild = InteractiveViewer(
               key: _interactiveViewerKey,
               transformationController: _transformController,
               minScale: _isOverlayOnly ? 1.0 : 0.5,
@@ -347,11 +327,69 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
                   if (copyButton != null) copyButton,
                 ],
               ),
-            ),
-          ),
+            );
+
+        final Widget gestureChild;
+        if (_isOverlayOnly) {
+          gestureChild = RawGestureDetector(
+            behavior: HitTestBehavior.translucent,
+            gestures: <Type, GestureRecognizerFactory>{
+              _TextRegionLongPressRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                    _TextRegionLongPressRecognizer
+                  >(
+                    () => _TextRegionLongPressRecognizer(
+                      hitTestBlock: _isPositionOnText,
+                    ),
+                    (_TextRegionLongPressRecognizer instance) {
+                      instance
+                        ..hitTestBlock = _isPositionOnText
+                        ..onLongPressStart = (details) {
+                          if (_activePointerCount > 1) return;
+                          _onLongPressStart(details);
+                        };
+                    },
+                  ),
+              if (_activeSelections.isNotEmpty)
+                TapGestureRecognizer:
+                    GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+                      TapGestureRecognizer.new,
+                      (TapGestureRecognizer instance) {
+                        instance.onTapDown = _handleOverlayTap;
+                      },
+                    ),
+            },
+            child: interactiveChild,
+          );
+        } else {
+          gestureChild = GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: _handleTapDown,
+            onDoubleTapDown: _handleDoubleTapDown,
+            onDoubleTap: _handleDoubleTap,
+            onLongPressStart: (details) {
+              if (_activePointerCount > 1) return;
+              _onLongPressStart(details);
+            },
+            child: interactiveChild,
+          );
+        }
+
+        return Listener(
+          onPointerDown: _handlePointerDown,
+          onPointerMove: _handlePointerMove,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: _handlePointerCancel,
+          child: gestureChild,
         );
       },
     );
+  }
+
+  bool _isPositionOnText(Offset globalPosition) {
+    final scenePoint = _sceneFromGlobal(globalPosition);
+    if (scenePoint == null) return false;
+    return _hitTestBlock(scenePoint) != null;
   }
 
   Offset? _sceneFromGlobal(Offset globalPoint) {
@@ -2539,5 +2577,32 @@ class _EditableBlockPainter extends CustomPainter {
     return oldDelegate.visual != visual ||
         oldDelegate.selection != selection ||
         oldDelegate.showBoundary != showBoundary;
+  }
+}
+
+/// A [LongPressGestureRecognizer] that only accepts when the press
+/// position is on a text region. If not on text, it rejects so that
+/// competing recognizers (e.g. motion photo playback) can win.
+class _TextRegionLongPressRecognizer extends LongPressGestureRecognizer {
+  bool Function(Offset globalPosition) hitTestBlock;
+
+  _TextRegionLongPressRecognizer({required this.hitTestBlock});
+
+  Offset? _initialGlobalPosition;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    _initialGlobalPosition = event.position;
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void didExceedDeadline() {
+    final pos = _initialGlobalPosition;
+    if (pos != null && hitTestBlock(pos)) {
+      super.didExceedDeadline();
+    } else {
+      resolve(GestureDisposition.rejected);
+    }
   }
 }

--- a/lib/widgets/text_overlay_widget.dart
+++ b/lib/widgets/text_overlay_widget.dart
@@ -297,9 +297,11 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
             behavior: _isOverlayOnly
                 ? HitTestBehavior.translucent
                 : HitTestBehavior.opaque,
-            onTapDown: _handleTapDown,
-            onDoubleTapDown: _handleDoubleTapDown,
-            onDoubleTap: _handleDoubleTap,
+            onTapDown: _isOverlayOnly
+                ? (_activeSelections.isNotEmpty ? _handleOverlayTap : null)
+                : _handleTapDown,
+            onDoubleTapDown: _isOverlayOnly ? null : _handleDoubleTapDown,
+            onDoubleTap: _isOverlayOnly ? null : _handleDoubleTap,
             onLongPressStart: (details) {
               if (_activePointerCount > 1) {
                 return;
@@ -1233,6 +1235,12 @@ class _TextOverlayWidgetState extends State<TextOverlayWidget> {
     _selectionDragInProgress = true;
     _selectionPointerDownScenePoint ??= scenePoint;
     HapticFeedback.mediumImpact();
+  }
+
+  void _handleOverlayTap(TapDownDetails details) {
+    if (_activeSelections.isNotEmpty) {
+      _clearSelection();
+    }
   }
 
   void _handleTapDown(TapDownDetails details) {

--- a/test/mobile_ocr_plugin_method_channel_test.dart
+++ b/test/mobile_ocr_plugin_method_channel_test.dart
@@ -15,18 +15,22 @@ void main() {
             case 'getPlatformVersion':
               return '42';
             case 'detectText':
-              return [
-                {
-                  'text': 'hello',
-                  'confidence': 0.9,
-                  'points': [
-                    {'x': 1.0, 'y': 2.0},
-                    {'x': 11.0, 'y': 2.0},
-                    {'x': 11.0, 'y': 7.0},
-                    {'x': 1.0, 'y': 7.0},
-                  ],
-                },
-              ];
+              return {
+                'blocks': [
+                  {
+                    'text': 'hello',
+                    'confidence': 0.9,
+                    'points': [
+                      {'x': 1.0, 'y': 2.0},
+                      {'x': 11.0, 'y': 2.0},
+                      {'x': 11.0, 'y': 7.0},
+                      {'x': 1.0, 'y': 7.0},
+                    ],
+                  },
+                ],
+                'imageWidth': 100,
+                'imageHeight': 200,
+              };
             case 'hasText':
               return true;
             default:
@@ -45,13 +49,16 @@ void main() {
   });
 
   test('detectText forwards path', () async {
-    final results = await platform.detectText(
+    final result = await platform.detectText(
       imagePath: '/tmp/test.png',
       includeAllConfidenceScores: true,
     );
-    expect(results, hasLength(1));
-    expect(results.first['text'], 'hello');
-    expect(results.first['points'], isNotEmpty);
+    final blocks = result['blocks'] as List;
+    expect(blocks, hasLength(1));
+    expect((blocks.first as Map)['text'], 'hello');
+    expect((blocks.first as Map)['points'], isNotEmpty);
+    expect(result['imageWidth'], 100);
+    expect(result['imageHeight'], 200);
   });
 
   test('hasText returns boolean result', () async {

--- a/test/mobile_ocr_plugin_test.dart
+++ b/test/mobile_ocr_plugin_test.dart
@@ -14,11 +14,11 @@ class MockMobileOcrPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  Future<List<Map<dynamic, dynamic>>> detectText({
+  Future<Map<dynamic, dynamic>> detectText({
     required String imagePath,
     bool includeAllConfidenceScores = false,
   }) async {
-    return [];
+    return {'blocks': [], 'imageWidth': 0, 'imageHeight': 0};
   }
 
   @override


### PR DESCRIPTION
Adds overlay-only mode that renders text boundaries without duplicating the image, using a custom hit-test render object to pass swipes/taps/zoom through to the underlying viewer while intercepting only long-press on detected text regions.